### PR TITLE
Revert auto ON HOLD and go back to auto cancel

### DIFF
--- a/src/code/Dibs/Model/Observer.php
+++ b/src/code/Dibs/Model/Observer.php
@@ -67,8 +67,8 @@ class Made_Dibs_Model_Observer
                 continue;
             }
 
-            $order->hold();
-            $order->addStatusHistoryComment("The order was automatically set ON HOLD due to more than $hoursUntilCancelled hours of gateway inactivity.");
+            $order->cancel();
+            $order->addStatusHistoryComment("The order was automatically cancelled due to more than $hoursUntilCancelled hours of gateway inactivity.");
             $order->save();
         }
     }


### PR DESCRIPTION
Revert "Changing so that Dibs autosets status ON HOLD instead of cancels orders when x hours of gateway inactivity has been reached"

This reverts commit d207092f117651226f89a9002b6ba0bf372ab6dc.